### PR TITLE
use ffmpeg to download m3u8  directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ futures = "0.3.30"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 ffmpeg-cli = "0.1.0"
+[features]
+ffmpeg=[]


### PR DESCRIPTION
 use command `ffmpeg - i "{url}" -f mp4 -c copy path/to/file `  

It might be better to add this as a command argument rather than as a Rust feature？

Also  don't know if this will work on Windows. 